### PR TITLE
Actually declare no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@
 #![doc = include_str!("../examples/simple.rs")]
 //! ```
 
+#![no_std]
+
 use core::pin::Pin;
 
 /// Sp stands for Structurally Pinned


### PR DESCRIPTION
This crate declares in its Cargo.toml that it is no_std, but doesn't declare it in the code. If I understand correctly, no_std crates need this declaration, or they will fail to compile in actual no_std environments.